### PR TITLE
Swift package manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ profile
 DerivedData
 *.hmap
 *.ipa
+.swiftpm
 
 # Bundler
 .bundle

--- a/Export.swift
+++ b/Export.swift
@@ -1,0 +1,2 @@
+
+@_exported import PostHog

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,16 @@ let package = Package(
         .target(
             name: "PostHog",
             dependencies: [],
-			path: "PostHog"
+            path: "PostHog",
+            cSettings: [
+                .headerSearchPath("PostHog"),
+                .headerSearchPath("Classes"),
+                .headerSearchPath("Classes/Internal"),
+                .headerSearchPath("Classes/Crypto"),
+                .headerSearchPath("Classes/Payloads"),
+                .headerSearchPath("Classes/Middlewares"),
+                .headerSearchPath("Vendor")
+            ]
 			),
 //        .testTarget(
 //            name: "PostHogTests",

--- a/PostHog/Classes/Internal/PHGPostHogUtils.h
+++ b/PostHog/Classes/Internal/PHGPostHogUtils.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
-#import <PostHog/PHGSerializableValue.h>
+#import "PHGSerializableValue.h"
+
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/PostHog/include/NSData+PHGGZIP.h
+++ b/PostHog/include/NSData+PHGGZIP.h
@@ -1,0 +1,1 @@
+../Classes/Internal/NSData+PHGGZIP.h

--- a/PostHog/include/ObjC.h
+++ b/PostHog/include/ObjC.h
@@ -1,0 +1,1 @@
+../Vendor/ObjC.h

--- a/PostHog/include/PHGAES256Crypto.h
+++ b/PostHog/include/PHGAES256Crypto.h
@@ -1,0 +1,1 @@
+../Classes/Crypto/PHGAES256Crypto.h

--- a/PostHog/include/PHGAliasPayload.h
+++ b/PostHog/include/PHGAliasPayload.h
@@ -1,0 +1,1 @@
+../Classes/Payloads/PHGAliasPayload.h

--- a/PostHog/include/PHGCapturePayload.h
+++ b/PostHog/include/PHGCapturePayload.h
@@ -1,0 +1,1 @@
+../Classes/Payloads/PHGCapturePayload.h

--- a/PostHog/include/PHGContext.h
+++ b/PostHog/include/PHGContext.h
@@ -1,0 +1,1 @@
+../Classes/Middlewares/PHGContext.h

--- a/PostHog/include/PHGCrypto.h
+++ b/PostHog/include/PHGCrypto.h
@@ -1,0 +1,1 @@
+../Classes/Crypto/PHGCrypto.h

--- a/PostHog/include/PHGFileStorage.h
+++ b/PostHog/include/PHGFileStorage.h
@@ -1,0 +1,1 @@
+../Classes/Internal/PHGFileStorage.h

--- a/PostHog/include/PHGHTTPClient.h
+++ b/PostHog/include/PHGHTTPClient.h
@@ -1,0 +1,1 @@
+../Classes/Internal/PHGHTTPClient.h

--- a/PostHog/include/PHGIdentifyPayload.h
+++ b/PostHog/include/PHGIdentifyPayload.h
@@ -1,0 +1,1 @@
+../Classes/Payloads/PHGIdentifyPayload.h

--- a/PostHog/include/PHGIntegration.h
+++ b/PostHog/include/PHGIntegration.h
@@ -1,0 +1,1 @@
+../Classes/PHGIntegration.h

--- a/PostHog/include/PHGMacros.h
+++ b/PostHog/include/PHGMacros.h
@@ -1,0 +1,1 @@
+../Classes/Internal/PHGMacros.h

--- a/PostHog/include/PHGMiddleware.h
+++ b/PostHog/include/PHGMiddleware.h
@@ -1,0 +1,1 @@
+../Classes/Middlewares/PHGMiddleware.h

--- a/PostHog/include/PHGPayload.h
+++ b/PostHog/include/PHGPayload.h
@@ -1,0 +1,1 @@
+../Classes/Payloads/PHGPayload.h

--- a/PostHog/include/PHGPayloadManager.h
+++ b/PostHog/include/PHGPayloadManager.h
@@ -1,0 +1,1 @@
+../Classes/Payloads/PHGPayloadManager.h

--- a/PostHog/include/PHGPostHog.h
+++ b/PostHog/include/PHGPostHog.h
@@ -1,0 +1,1 @@
+../Classes/PHGPostHog.h

--- a/PostHog/include/PHGPostHogConfiguration.h
+++ b/PostHog/include/PHGPostHogConfiguration.h
@@ -1,0 +1,1 @@
+../Classes/PHGPostHogConfiguration.h

--- a/PostHog/include/PHGPostHogIntegration.h
+++ b/PostHog/include/PHGPostHogIntegration.h
@@ -1,0 +1,1 @@
+../Classes/Internal/PHGPostHogIntegration.h

--- a/PostHog/include/PHGPostHogUtils.h
+++ b/PostHog/include/PHGPostHogUtils.h
@@ -1,0 +1,1 @@
+../Classes/Internal/PHGPostHogUtils.h

--- a/PostHog/include/PHGReachability.h
+++ b/PostHog/include/PHGReachability.h
@@ -1,0 +1,1 @@
+../Vendor/PHGReachability.h

--- a/PostHog/include/PHGScreenPayload.h
+++ b/PostHog/include/PHGScreenPayload.h
@@ -1,0 +1,1 @@
+../Classes/Payloads/PHGScreenPayload.h

--- a/PostHog/include/PHGSerializableValue.h
+++ b/PostHog/include/PHGSerializableValue.h
@@ -1,0 +1,1 @@
+../Classes/PHGSerializableValue.h

--- a/PostHog/include/PHGStorage.h
+++ b/PostHog/include/PHGStorage.h
@@ -1,0 +1,1 @@
+../Classes/Internal/PHGStorage.h

--- a/PostHog/include/PHGStoreKitCapturer.h
+++ b/PostHog/include/PHGStoreKitCapturer.h
@@ -1,0 +1,1 @@
+../Classes/Internal/PHGStoreKitCapturer.h

--- a/PostHog/include/PHGUserDefaultsStorage.h
+++ b/PostHog/include/PHGUserDefaultsStorage.h
@@ -1,0 +1,1 @@
+../Classes/Internal/PHGUserDefaultsStorage.h

--- a/PostHog/include/PHGUtils.h
+++ b/PostHog/include/PHGUtils.h
@@ -1,0 +1,1 @@
+../Classes/Internal/PHGUtils.h

--- a/PostHog/include/UIViewController+PHGScreen.h
+++ b/PostHog/include/UIViewController+PHGScreen.h
@@ -1,0 +1,1 @@
+../Classes/Internal/UIViewController+PHGScreen.h


### PR DESCRIPTION
**What does this PR do?**

Attempting to include the posthog library through swift pm failed for a number of reasons:

* Unable to find objective-c header files on the search path
* Public interfaces weren't exposed to swift
* Use of fully-qualified import statements

I followed this article to rectify the issues: https://medium.com/@joesusnick/swift-package-manager-with-a-mixed-swift-and-objective-c-project-part-2-2-e71dad234e6

**Where should the reviewer start?**

Use Swift Package Manager to include this branch in a Swift project. The project should build successfully and have access to the PostHog package.

**How should this be manually tested?**

After including the package, follow the Swift instructions here: https://posthog.com/docs/integrations/ios-integration#configuration

**What are the relevant tickets?**

https://github.com/PostHog/posthog-ios/issues/1
