### PR TITLE
Remove Xcode Warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
             name: "PostHog",
             dependencies: [],
             path: "PostHog/",
-            exclude: ["SwiftSources"],
+            exclude: ["SwiftSources", "Info.plist"],
             sources: ["Classes/",
                       "Classes/Crypto/",
                       "Classes/Internal/",


### PR DESCRIPTION
**What does this PR do?**
Remove Xcode warning about an unused file when the package is used as a Swift Package. It is done by excluding the unused file `PostHog/Info.plist` in the Swift Package manifest file.

**Where should the reviewer start?**
Look into `Package.swift` file, line 23

**How should this be manually tested?**
None.

**Any background context you want to provide?**
The ignored file, `Info.plist`, is not being used when the package is managed by Swift Package Manager.

**What are the relevant tickets?**
None.

**Screenshots or screencasts (if UI/UX change)**
None.

**Questions:**
- Does the docs need an update?
    - No
- Are there any security concerns?
    - No
- Do we need to update engineering / success?
    - No, except we need to make a new release